### PR TITLE
fix: Warn when expected image ID is empty instead of silently skipping

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -207,7 +207,16 @@ func (opts *UpdaterOptions) UpdateContainer(serviceName string) error {
 	}
 	
 	// Compare image IDs and update if different
-	if expectedImageID != "" && currentImageID != expectedImageID {
+	if expectedImageID == "" {
+		// A blank expectedImageID means the image name from docker compose config
+		// was not found in the local Docker daemon (e.g. the name lacks a :latest
+		// suffix, or the image hasn't been pulled yet). This should not silently
+		// report "already up to date".
+		opts.warnIfEnabled(sw, fmt.Sprintf("Expected image ID not found for %s — image may not be pulled yet or name lacks a tag", serviceName))
+		return nil
+	}
+
+	if currentImageID != expectedImageID {
 		sw.UpdateSuffix(fmt.Sprintf("Updating and restarting %s", serviceName))
 		
 		if err := opts.RestartContainer(serviceName); err != nil {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -152,6 +152,16 @@ func (c *Client) GetLatestImageId(containerID string) (string, error) {
 	return c.GetImageId(imageName)
 }
 
+// normalizeImageName ensures image names have a tag, defaulting to :latest if no tag is present.
+// Docker images are stored in RepoTags with a tag, so a bare name like "nginx" won't match
+// the cached "nginx:latest" entry without this normalization.
+func normalizeImageName(name string) string {
+	if !strings.Contains(name, ":") {
+		return name + ":latest"
+	}
+	return name
+}
+
 // GetImageId gets the image ID for a specific image reference (name:tag)
 func (c *Client) GetImageId(imageName string) (string, error) {
 	if imageName == "" {
@@ -163,8 +173,13 @@ func (c *Client) GetImageId(imageName string) (string, error) {
 		return "", err
 	}
 
+	// Normalize image name by appending :latest if no tag is present
+	// Docker images are always stored with a tag in RepoTags, so a bare
+	// name like "nginx" won't match the cached "nginx:latest" entry.
+	normalizedName := normalizeImageName(imageName)
+
 	c.mu.RLock()
-	image, exists := c.imageCache[imageName]
+	image, exists := c.imageCache[normalizedName]
 	c.mu.RUnlock()
 	if exists {
 		imageID := image.ID

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -234,3 +234,87 @@ func TestRefreshClearsContainerCache(t *testing.T) {
 		t.Errorf("expected 2 inspect calls total, got %d", n)
 	}
 }
+
+// TestNormalizeImageName verifies the normalizeImageName helper appends :latest
+// to bare image names and leaves tagged names unchanged.
+func TestNormalizeImageName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"nginx", "nginx:latest"},
+		{"nginx:latest", "nginx:latest"},
+		{"nginx:1.21", "nginx:1.21"},
+		{"library/nginx:alpine", "library/nginx:alpine"},
+		{"myregistry.io/nginx", "myregistry.io/nginx:latest"},
+		{"myregistry.io/nginx:latest", "myregistry.io/nginx:latest"},
+		{"ubuntu", "ubuntu:latest"},
+		{"docker.io/library/ubuntu:24.04", "docker.io/library/ubuntu:24.04"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeImageName(tt.name)
+			if got != tt.want {
+				t.Errorf("normalizeImageName(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetImageIdWithBareName verifies that GetImageId("nginx") resolves to
+// the same image as GetImageId("nginx:latest") due to normalizeImageName.
+func TestGetImageIdWithBareName(t *testing.T) {
+	fake := &fakeDockerAPI{
+		images: makeImages("nginx:latest"),
+	}
+	c := newTestClient(fake)
+
+	// Look up with explicit tag first to populate cache.
+	idWithTag, err := c.GetImageId("nginx:latest")
+	if err != nil {
+		t.Fatalf("GetImageId(\"nginx:latest\"): %v", err)
+	}
+	if idWithTag == "" {
+		t.Fatal("expected non-empty ID for nginx:latest")
+	}
+
+	// Reset call counter so we can verify the bare-name lookup hits cache.
+	fake.imageListCalls.Store(0)
+
+	// Bare name should resolve to the same image via normalization.
+	idBare, err := c.GetImageId("nginx")
+	if err != nil {
+		t.Fatalf("GetImageId(\"nginx\"): %v", err)
+	}
+	if idBare != idWithTag {
+		t.Errorf("GetImageId(\"nginx\") = %q, want %q (same as tagged lookup)", idBare, idWithTag)
+	}
+
+	// Should have used cache, not a second API call.
+	if n := fake.imageListCalls.Load(); n != 0 {
+		t.Errorf("ImageList called %d times, want 0 (cache hit)", n)
+	}
+}
+
+// TestGetImageIdReturnsEmptyForUnknownImage verifies that looking up an image
+// not present in the local daemon returns ("", nil) rather than an error.
+func TestGetImageIdReturnsEmptyForUnknownImage(t *testing.T) {
+	fake := &fakeDockerAPI{
+		images: makeImages("nginx:latest"),
+	}
+	c := newTestClient(fake)
+
+	// Prime the cache.
+	if _, err := c.GetImageId("nginx:latest"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// A different, unknown image should return empty string, not error.
+	id, err := c.GetImageId("unknown:image")
+	if err != nil {
+		t.Fatalf("GetImageId(\"unknown:image\"): expected nil error, got %v", err)
+	}
+	if id != "" {
+		t.Errorf("GetImageId(\"unknown:image\") = %q, want empty string", id)
+	}
+}


### PR DESCRIPTION
Automated fix from Claude Code burn.

**Task:** t_813cc707
**Branch:** claude-fix/t-813cc707-1778617819

---

Two changes:

1. **internal/docker/docker.go** — Added `normalizeImageName` helper that appends `:latest` to bare image names (e.g. `nginx` → `nginx:latest`) before the `GetImageId` cache lookup. Docker stores images with full tags in RepoTags, so a bare name would never match.

2. **internal/core/core.go** — Split the update logic into three cases instead of two: when `expectedImageID` is empty (image not found locally), it now shows a warning via `warnIfEnabled` instead of silently reporting the container as "already up to date". The normal update and up-to-date cases remain unchanged.

Found by: Claude Code burn (review, $0.2255)