### PR TITLE
fix: handle multi-line output from docker compose ps -q

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -57,7 +57,7 @@ func (opts *Options) GetCurrentContainerId(serviceName string) (string, error) {
 		return "", err
 	}
 
-\treturn parseContainerID(output), nil
+	return parseContainerID(output), nil
 }
 
 // parseContainerID parses the output of `docker compose ps -q` and returns the first
@@ -65,16 +65,16 @@ func (opts *Options) GetCurrentContainerId(serviceName string) (string, error) {
 // only the first line is returned. This handles the case where docker compose ps -q
 // returns one container ID per line for services with multiple replicas.
 func parseContainerID(output []byte) string {
-\trawID := strings.TrimSpace(string(output))
-\tif rawID == "" {
-\t\treturn ""
-\t}
-\tlines := strings.Split(rawID, "\n")
-\tcontainerID := strings.TrimSpace(lines[0])
-\tif len(lines) > 1 {
-\t\tlog.Printf("debug: GetCurrentContainerId found %d container IDs, using first: %s", len(lines), containerID)
-\t}
-\treturn containerID
+	rawID := strings.TrimSpace(string(output))
+	if rawID == "" {
+		return ""
+	}
+	lines := strings.Split(rawID, "\n")
+	containerID := strings.TrimSpace(lines[0])
+	if len(lines) > 1 {
+		log.Printf("debug: GetCurrentContainerId found %d container IDs, using first: %s", len(lines), containerID)
+	}
+	return containerID
 }
 
 // ValidateServiceExists checks if a service exists in the docker-compose file

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -57,16 +57,24 @@ func (opts *Options) GetCurrentContainerId(serviceName string) (string, error) {
 		return "", err
 	}
 
-	// Parse output - trim whitespace and return the first container ID.
-	// docker compose ps -q can return multiple IDs when a service has
-	// multiple replicas. Split on newlines and use the first non-empty line.
-	rawID := strings.TrimSpace(string(output))
-	lines := strings.Split(rawID, "\n")
-	containerID := strings.TrimSpace(lines[0])
-	if len(lines) > 1 {
-		log.Printf("debug: GetCurrentContainerId found %d container IDs for service '%s', using first: %s", len(lines), serviceName, containerID)
-	}
-	return containerID, nil
+\treturn parseContainerID(output), nil
+}
+
+// parseContainerID parses the output of `docker compose ps -q` and returns the first
+// non-empty container ID. If the output contains multiple lines (multiple replicas),
+// only the first line is returned. This handles the case where docker compose ps -q
+// returns one container ID per line for services with multiple replicas.
+func parseContainerID(output []byte) string {
+\trawID := strings.TrimSpace(string(output))
+\tif rawID == "" {
+\t\treturn ""
+\t}
+\tlines := strings.Split(rawID, "\n")
+\tcontainerID := strings.TrimSpace(lines[0])
+\tif len(lines) > 1 {
+\t\tlog.Printf("debug: GetCurrentContainerId found %d container IDs, using first: %s", len(lines), containerID)
+\t}
+\treturn containerID
 }
 
 // ValidateServiceExists checks if a service exists in the docker-compose file

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"fmt"
+	"log"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -56,8 +57,15 @@ func (opts *Options) GetCurrentContainerId(serviceName string) (string, error) {
 		return "", err
 	}
 
-	// Parse output - trim whitespace and return container ID
-	containerID := strings.TrimSpace(string(output))
+	// Parse output - trim whitespace and return the first container ID.
+	// docker compose ps -q can return multiple IDs when a service has
+	// multiple replicas. Split on newlines and use the first non-empty line.
+	rawID := strings.TrimSpace(string(output))
+	lines := strings.Split(rawID, "\n")
+	containerID := strings.TrimSpace(lines[0])
+	if len(lines) > 1 {
+		log.Printf("debug: GetCurrentContainerId found %d container IDs for service '%s', using first: %s", len(lines), serviceName, containerID)
+	}
 	return containerID, nil
 }
 

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -1,0 +1,68 @@
+package compose
+
+import (
+	"testing"
+)
+
+func TestParseContainerID(t *testing.T) {
+	tests := []struct {
+		name   string
+		output []byte
+		want   string
+	}{
+		{
+			name:   "single line with trailing newline",
+			output: []byte("abc123def456\n"),
+			want:   "abc123def456",
+		},
+		{
+			name:   "multi-line multiple replicas",
+			output: []byte("abc123def456\ndef789abc012\n"),
+			want:   "abc123def456",
+		},
+		{
+			name:   "three replica IDs",
+			output: []byte("abc123\ndef456\nghi789\n"),
+			want:   "abc123",
+		},
+		{
+			name:   "no trailing newline",
+			output: []byte("abc123def456"),
+			want:   "abc123def456",
+		},
+		{
+			name:   "with surrounding whitespace",
+			output: []byte("  abc123def456  \n"),
+			want:   "abc123def456",
+		},
+		{
+			name:   "empty output",
+			output: []byte(""),
+			want:   "",
+		},
+		{
+			name:   "only whitespace",
+			output: []byte("  \n  \n"),
+			want:   "",
+		},
+		{
+			name:   "multiple lines with empty first line",
+			output: []byte("\nabc123def456\n"),
+			want:   "",
+		},
+		{
+			name:   "single newline only",
+			output: []byte("\n"),
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseContainerID(tt.output)
+			if got != tt.want {
+				t.Errorf("parseContainerID(%q) = %q, want %q", string(tt.output), got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -48,7 +48,7 @@ func TestParseContainerID(t *testing.T) {
 		{
 			name:   "multiple lines with empty first line",
 			output: []byte("\nabc123def456\n"),
-			want:   "",
+			want:   "abc123def456",
 		},
 		{
 			name:   "single newline only",


### PR DESCRIPTION
Automated fix from Claude Code burn.

**Problem:** `GetCurrentContainerId` in `compose.go` passes the entire multi-line output of `docker compose ps -q` to Docker's ContainerInspect. When a service has multiple replicas, this returns multiple container IDs (one per line), and ContainerInspect fails with "No such container".

**Fix:** Split the output on newlines and return only the first non-empty container ID. If more than one ID is found, a debug message is logged.

**Tests added:** `TestParseContainerID` in `internal/compose/compose_test.go` covers:
- Single line (normal case)
- Multi-line (multiple replicas)
- Three replica IDs
- No trailing newline
- Whitespace around the ID
- Empty output
- Only whitespace
- Empty first line
- Single newline only

**Task:** t_a8680df6
**Branch:** claude-fix/t-a8680df6-1778617794