### PR TITLE
fix: capture and return filepath.Abs error in NewOptions

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -15,12 +15,15 @@ type Options struct {
 }
 
 // NewOptions creates docker-compose options from a compose file path
-func NewOptions(composeFilePath string) *Options {
-	absPath, _ := filepath.Abs(composeFilePath)
+func NewOptions(composeFilePath string) (*Options, error) {
+	absPath, err := filepath.Abs(composeFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve compose file path: %w", err)
+	}
 	return &Options{
 		ComposeFile: filepath.Base(absPath),
 		WorkingDir:  filepath.Dir(absPath),
-	}
+	}, nil
 }
 
 // GetServiceNames executes `docker compose config --services` and returns service names

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -50,7 +50,10 @@ func isInteractiveTerminal() bool {
 
 // NewUpdaterOptions creates new updater options
 func NewUpdaterOptions(composeFile string, showWarnings bool, nonInteractive bool) (*UpdaterOptions, error) {
-	composeOpts := compose.NewOptions(composeFile)
+	composeOpts, err := compose.NewOptions(composeFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create compose options: %w", err)
+	}
 	
 	dockerClient, err := docker.NewClient()
 	if err != nil {


### PR DESCRIPTION
Automated fix from Claude Code burn.

**Task:** t_f06f4257
**Found by:** Claude Code burn (review, $0.2255)

---
In `NewOptions` (compose.go:18), the error from `filepath.Abs` was silently discarded with `_`, causing an invalid path to silently fall back to the current directory. This fix:

- Changes `NewOptions` signature to return `(*Options, error)`
- Captures the `filepath.Abs` error and propagates it as a wrapped error
- Updates the caller in `core.go:53` to check and propagate the error

Closes the gap where invalid paths would go uncaught.